### PR TITLE
End the request so it actually gets sent

### DIFF
--- a/src/main/java/vertx/Foo2Handler.java
+++ b/src/main/java/vertx/Foo2Handler.java
@@ -22,6 +22,6 @@ public class Foo2Handler implements Handler<RoutingContext> {
 						request.response().setStatusCode(200).end("FOO\n" + body.toString());
 					});
 			}
-		);
+		).end();
 	}
 }


### PR DESCRIPTION
You had omitted to end your request, meaning that it wouldn't get sent (and therefore wouldn't get processed, and you'd never see the bodyhandler get called)